### PR TITLE
Switch to darker gamer red

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -6,7 +6,7 @@
   class="flex flex-col items-center justify-center gap-8 text-gray-700 dark:text-gray-300 md:flex-row"
 >
 <div
-  class="[&>p]:mb-4 [&>p>strong]:text-purple-600 dark:[&>p>strong]:text-purple-400 [&>p>strong]:font-normal [&>p>strong]:font-mono text-pretty order-2 md:order-1"
+  class="[&>p]:mb-4 [&>p>strong]:text-red-600 dark:[&>p>strong]:text-red-400 [&>p>strong]:font-normal [&>p>strong]:font-mono text-pretty order-2 md:order-1"
 >
   <p class="mt-4">
     👋 Hola, soy Yeiner David López, <strong>Desarrollador de Software</strong> y <strong>Analista de Soporte IT</strong> con más de <strong>4 años de experiencia</strong> en soporte técnico, redes e infraestructura tecnológica.

--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,5 +1,5 @@
 <span
-  class="bg-purple-100 text-purple-800 text-xs font-medium me-2 px-2.5 py-0.5 rounded-full dark:bg-gray-700 dark:text-purple-400 border border-purple-400"
+  class="bg-red-100 text-red-800 text-xs font-medium me-2 px-2.5 py-0.5 rounded-full dark:bg-gray-700 dark:text-red-400 border border-red-400"
 >
   <slot />
 </span>

--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -15,11 +15,11 @@ const { title, company, description, date } = Astro.props;
 >
   <div class="">
     <div class="top-0">
-      <span class="text-purple-400 -left-[42px] absolute rounded-full text-5xl"
+      <span class="text-red-400 -left-[42px] absolute rounded-full text-5xl"
         >&bull;</span
       >
 
-      <h3 class="text-xl font-bold text-purple-400">{title}</h3>
+      <h3 class="text-xl font-bold text-red-400">{title}</h3>
       <h4 class="font-semibold text-lg text-gray-600 dark:text-white">
         {company}
       </h4>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,7 +36,7 @@ const navItems = [
       {
         navItems.map((link) => (
           <a
-            class="relative block px-2 py-2 transition hover:text-purple-500 dark:hover:text-purple-400"
+            class="relative block px-2 py-2 transition hover:text-red-500 dark:hover:text-red-400"
             aria-label={link.label}
             href={link.url}
           >
@@ -56,7 +56,7 @@ const navItems = [
     {
       navItems.map((link) => (
         <a
-          class="block px-4 py-2 text-center transition hover:text-purple-500 dark:hover:text-purple-400"
+          class="block px-4 py-2 text-center transition hover:text-red-500 dark:hover:text-red-400"
           aria-label={link.label}
           href={link.url}
         >
@@ -77,9 +77,9 @@ const navItems = [
         if (entry.isIntersecting) {
           navItems.forEach((item) => {
             if (item.getAttribute("aria-label") == entry.target.id) {
-              item.classList.add("text-purple-500")
+              item.classList.add("text-red-500")
             } else {
-              item.classList.remove("text-purple-500")
+              item.classList.remove("text-red-500")
             }
           })
         }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -17,12 +17,12 @@ import MailIcon from "../icons/Mail.astro";
     <div class="flex flex-col gap-5">
       <div>
         <h1 class="text-4xl sm:text-5xl font-bold text-pretty">
-          Hola, <span class="text-purple-800 opacity-80 dark:text-purple-300"
+          Hola, <span class="text-red-700 opacity-80 dark:text-red-300"
             >soy Yeiner</span
           > 👋
         </h1>
         <span
-          class="font-semibold inline-flex animate-background-shine bg-[linear-gradient(110deg,#c084fc,45%,#e0c3ff,55%,#c084fc)] dark:bg-[linear-gradient(110deg,#f3e8ff,45%,#c084fc,55%,#f3e8ff)] bg-[length:250%_100%] bg-clip-text text-lg sm:text-xl text-transparent"
+          class="font-semibold inline-flex animate-background-shine bg-[linear-gradient(110deg,#b91c1c,45%,#dc2626,55%,#b91c1c)] dark:bg-[linear-gradient(110deg,#7f1d1d,45%,#b91c1c,55%,#7f1d1d)] bg-[length:250%_100%] bg-clip-text text-lg sm:text-xl text-transparent"
           >Software Developer and Engineer
         </span>
       </div>
@@ -34,27 +34,27 @@ import MailIcon from "../icons/Mail.astro";
   </div>
   <p class="text-base sm:text-xl mt-6 md:mt-10 text-pretty">
     🔧+4 años de experiencia en 
-    <span class="text-purple-600 dark:text-purple-400">soporte técnico</span> e
-    <span class="text-purple-600 dark:text-purple-400">infraestructura TI</span>, incluyendo gestión de 
-    <span class="text-purple-600 dark:text-purple-400">Active Directory</span>, administración de 
-    <span class="text-purple-600 dark:text-purple-400">Windows Server</span>, 
-    <span class="text-purple-600 dark:text-purple-400">copias de seguridad</span>, soporte en entornos
-    <span class="text-purple-600 dark:text-purple-400">Linux</span> y
-    <span class="text-purple-600 dark:text-purple-400">Google Workspace</span>.
+    <span class="text-red-600 dark:text-red-400">soporte técnico</span> e
+    <span class="text-red-600 dark:text-red-400">infraestructura TI</span>, incluyendo gestión de 
+    <span class="text-red-600 dark:text-red-400">Active Directory</span>, administración de 
+    <span class="text-red-600 dark:text-red-400">Windows Server</span>, 
+    <span class="text-red-600 dark:text-red-400">copias de seguridad</span>, soporte en entornos
+    <span class="text-red-600 dark:text-red-400">Linux</span> y
+    <span class="text-red-600 dark:text-red-400">Google Workspace</span>.
   </p>
   <p class="text-base sm:text-xl mt-6 md:mt-10 text-pretty">
     💻+2 años de experiencia desarrollando soluciones 
-    <span class="text-purple-600 dark:text-purple-400">web</span> con
-    <span class="text-purple-600 dark:text-purple-400">HTML</span>,
-    <span class="text-purple-600 dark:text-purple-400">CSS</span>, 
-    <span class="text-purple-600 dark:text-purple-400">JavaScript</span>,
-    <span class="text-purple-600 dark:text-purple-400">React</span>,  
-    <span class="text-purple-600 dark:text-purple-400">Angular</span> y 
-    <span class="text-purple-600 dark:text-purple-400">CMS</span>. Apasionado por el diseño 
-    <span class="text-purple-600 dark:text-purple-400">UI/UX</span>, la automatización con 
-    <span class="text-purple-600 dark:text-purple-400">Python</span> y el desarrollo de aplicaciones modernas basadas en frameworks
-    <span class="text-purple-600 dark:text-purple-400">JavaScript</span> y
-    <span class="text-purple-600 dark:text-purple-400">bases de datos relacionales</span>.
+    <span class="text-red-600 dark:text-red-400">web</span> con
+    <span class="text-red-600 dark:text-red-400">HTML</span>,
+    <span class="text-red-600 dark:text-red-400">CSS</span>, 
+    <span class="text-red-600 dark:text-red-400">JavaScript</span>,
+    <span class="text-red-600 dark:text-red-400">React</span>,  
+    <span class="text-red-600 dark:text-red-400">Angular</span> y 
+    <span class="text-red-600 dark:text-red-400">CMS</span>. Apasionado por el diseño 
+    <span class="text-red-600 dark:text-red-400">UI/UX</span>, la automatización con 
+    <span class="text-red-600 dark:text-red-400">Python</span> y el desarrollo de aplicaciones modernas basadas en frameworks
+    <span class="text-red-600 dark:text-red-400">JavaScript</span> y
+    <span class="text-red-600 dark:text-red-400">bases de datos relacionales</span>.
   </p>
   <nav class="flex flex-wrap gap-4 mt-8">
     <SocialPill href="https://www.linkedin.com/in/ydlopez11/" target="_blank">

--- a/src/components/Technologies.astro
+++ b/src/components/Technologies.astro
@@ -26,12 +26,12 @@ import ChatGPT from "../logos/ChatGPT.astro";
 ---
 
 <p class="my-8 text-pretty md:text-lg max-w-[740px]">
-  En mi viaje por el <span class="text-purple-600 dark:text-purple-400"
+  En mi viaje por el <span class="text-red-600 dark:text-red-400"
     >mundo del desarrollo web</span
-  >, he cultivado <span class="text-purple-600 dark:text-purple-400"
+  >, he cultivado <span class="text-red-600 dark:text-red-400"
     >experiencia y habilidades</span
   > en una variedad de tecnologías. <span
-    class="text-purple-600 dark:text-purple-400 font-semibold"
+    class="text-red-600 dark:text-red-400 font-semibold"
     >Mi stack tecnológico incluye</span
   >:
 </p>
@@ -39,14 +39,14 @@ import ChatGPT from "../logos/ChatGPT.astro";
 <div class="grid md:grid-cols-2 md:grid-rows-2 gap-6 md:place-content-center">
   <!-- Card 1 -->
   <div
-    class="card relative overflow-hidden rounded-2xl bg-purple shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
+    class="card relative overflow-hidden rounded-2xl bg-red-700 shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
   >
     <!-- Light effect -->
     <div
       class="light-effect absolute w-56 h-56
       bg-gradient-to-r
-      from-blue-100 to-purple-300
-      dark:from-blue-950 dark:to-purple-950
+      from-blue-100 to-red-600
+      dark:from-blue-950 dark:to-red-900
       rounded-full opacity-0 blur-3xl transform
       -translate-x-1/2 -translate-y-1/2 pointer-events-none
       transition-opacity duration-300"
@@ -92,14 +92,14 @@ import ChatGPT from "../logos/ChatGPT.astro";
 
   <!-- Card 2 -->
   <div
-    class="card relative overflow-hidden rounded-2xl bg-purple shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
+    class="card relative overflow-hidden rounded-2xl bg-red-700 shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
   >
     <!-- Light effect -->
     <div
       class="light-effect absolute w-56 h-56
       bg-gradient-to-r
-      from-blue-100 to-purple-300
-      dark:from-blue-950 dark:to-purple-950
+      from-blue-100 to-red-600
+      dark:from-blue-950 dark:to-red-900
       rounded-full opacity-0 blur-3xl transform
       -translate-x-1/2 -translate-y-1/2 pointer-events-none
       transition-opacity duration-300"
@@ -151,14 +151,14 @@ import ChatGPT from "../logos/ChatGPT.astro";
 
   <!-- Card 3 -->
   <div
-    class="card relative overflow-hidden rounded-2xl bg-purple shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
+    class="card relative overflow-hidden rounded-2xl bg-red-700 shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
   >
     <!-- Light effect -->
     <div
       class="light-effect absolute w-56 h-56
       bg-gradient-to-r
-      from-blue-100 to-purple-300
-      dark:from-blue-950 dark:to-purple-950
+      from-blue-100 to-red-600
+      dark:from-blue-950 dark:to-red-900
       rounded-full opacity-0 blur-3xl transform
       -translate-x-1/2 -translate-y-1/2 pointer-events-none
       transition-opacity duration-300"
@@ -202,14 +202,14 @@ import ChatGPT from "../logos/ChatGPT.astro";
 
   <!-- Card 4 -->
   <div
-    class="card relative overflow-hidden rounded-2xl bg-purple shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
+    class="card relative overflow-hidden rounded-2xl bg-red-700 shadow-2xl border dark:border-neutral-900 hover:shadow-lg transition-shadow duration-300"
   >
     <!-- Light effect -->
     <div
       class="light-effect absolute w-56 h-56
       bg-gradient-to-r
-      from-blue-100 to-purple-300
-      dark:from-blue-950 dark:to-purple-950
+      from-blue-100 to-red-600
+      dark:from-blue-950 dark:to-red-900
       rounded-full opacity-0 blur-3xl transform
       -translate-x-1/2 -translate-y-1/2 pointer-events-none
       transition-opacity duration-300"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,7 +32,7 @@ const { description, title } = Astro.props;
     <div
       class="absolute top-0 bottom-0 z-[-2] min-h-screen w-full bg-gray-50 dark:bg-neutral-950
     bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(255,255,255,1),rgba(243,232,255,0.7))]
-    dark:bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
+    dark:bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(30,58,138,0.4),rgba(255,255,255,0))]"
     >
     </div>
 


### PR DESCRIPTION
## Summary
- darken hero intro gradient
- restyle technology cards with deeper red
- adjust dark-mode radial background to blue

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a54444d88331a76ed93da655cfbe